### PR TITLE
Throw exception when response body is empty to make this debuggable.

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -22,6 +22,7 @@ use CURLFile;
 use DateTime;
 use Exception;
 use RuntimeException;
+use pnoeric\Exception\EmptyResponseBodyException;
 use stdClass;
 
 use function is_int;
@@ -954,6 +955,13 @@ class DiscourseAPI {
 		$body           = curl_exec( $ch );
 		$httpResultCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
 		curl_close( $ch );
+
+        if ($body === false) {
+            throw new EmptyResponseBodyException(
+                    "Empty response from $httpMethod request: $url " . json_encode($query),
+                    $httpResultCode
+            );
+        }
 
 		// build return object
 		$res            = new stdClass();

--- a/src/Exception/EmptyResponseBodyException.php
+++ b/src/Exception/EmptyResponseBodyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace pnoeric\Exception;
+
+use Exception;
+
+final class EmptyResponseBodyException extends Exception
+{
+
+}


### PR DESCRIPTION
Assuming that there's something wrong when `curl_exec` returns `false`.